### PR TITLE
Bug: parameters validated on wrong verb.

### DIFF
--- a/spec/grape/api/required_parameters_with_invalid_method_spec.rb
+++ b/spec/grape/api/required_parameters_with_invalid_method_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Grape::Endpoint do
+  subject { Class.new(Grape::API) }
+
+  def app
+    subject
+  end
+
+  before do
+    subject.namespace do
+      params do
+        requires :id, desc: 'Identifier.'
+      end
+      get ':id' do
+      end
+    end
+  end
+
+  context 'post' do
+    it '405' do
+      post '/something'
+      expect(last_response.status).to eq 405
+    end
+  end
+end


### PR DESCRIPTION
This spec should probably be refactored into existing specs. Looks like parameter validation tries to run for other verbs, but didn't debug.
